### PR TITLE
fix viba 2 return value

### DIFF
--- a/src/LocalMapping.cc
+++ b/src/LocalMapping.cc
@@ -227,8 +227,6 @@ void LocalMapping::Run() {
                 std::cout << "start VIBA 1" << std::endl;
                 mpCurrentKeyFrame->GetMap()->SetIniertialBA1();
                 InitializeIMU(ImuInitializater::ImuInitType::VIBA1_G, ImuInitializater::ImuInitType::VIBA1_A, true);
-
-                isDoneVIBA = true;
                 std::cout << "end VIBA 1" << std::endl;
               }
             } else if (!mpCurrentKeyFrame->GetMap()->GetIniertialBA2()) {
@@ -236,7 +234,7 @@ void LocalMapping::Run() {
                     std::cout << "start VIBA 2" << std::endl;
                     mpCurrentKeyFrame->GetMap()->SetIniertialBA2();
                     InitializeIMU(ImuInitializater::ImuInitType::VIBA2_G, ImuInitializater::ImuInitType::VIBA2_A, true);
-
+                    isDoneVIBA = true;
                     std::cout << "end VIBA 2" << std::endl;
                 }
             }


### PR DESCRIPTION
The function 'getIsDoneVIBA' returns true when VIBA1 finishes.
This can cause issues as there are big jumps in the estimated pose while getting VIBA2.
This PR changes the return value to VIBA2 finished.